### PR TITLE
GL 6.2 API addition remove group

### DIFF
--- a/gitlab3/_api_definition.py
+++ b/gitlab3/_api_definition.py
@@ -76,7 +76,7 @@ class CurrentUser(APIDefinition):
 
 class Group(APIDefinition):
     url = '/groups/:id'
-    actions = [ _LIST, _GET, _ADD ]
+    actions = [ _LIST, _GET, _ADD, _DELETE ]
     required_params = [
         'name',
         'path',


### PR DESCRIPTION
Removing groups is now part of GitLab 6.2.

https://github.com/gitlabhq/gitlabhq/blob/6-2-stable/doc/api/groups.md#remove-group
