### PR TITLE
GL 6.2 API addition remove project

### DIFF
--- a/gitlab3/_api_definition.py
+++ b/gitlab3/_api_definition.py
@@ -129,7 +129,7 @@ class Note(APIDefinition):
 
 class Project(APIDefinition):
     url = '/projects/:id'
-    actions = [ _LIST, _GET, _ADD ]
+    actions = [ _LIST, _GET, _ADD, _DELETE ]
     required_params = [
         'name',
     ]


### PR DESCRIPTION
Removing projects is now part of GitLab 6.2.

https://github.com/gitlabhq/gitlabhq/blob/6-2-stable/doc/api/projects.md#remove-project
