### PR TITLE
Feature/parameters for get on url

### DIFF
--- a/gitlab3/__init__.py
+++ b/gitlab3/__init__.py
@@ -14,6 +14,7 @@ import re
 import requests
 from datetime import tzinfo, timedelta, datetime
 from math import ceil
+import urllib
 
 from . import exceptions
 from ._api_definition import GitLab as _GitLabAPIDefinition
@@ -427,6 +428,9 @@ class _GitLabAPI(object):
         url = self._get_url(api_url, addl_keys)
         #print "%s %s, data=%s" % (request_fn.__name__.upper(), url, str(data))
         try:
+            if request_fn == requests.get:
+              url = url + '?' + urllib.urlencode(data,doseq=True)
+              data=None
             r = request_fn(url, headers=self._headers, data=data,
                            **self._requests_kwargs)
         except requests.exceptions.RequestException:

--- a/gitlab3/__init__.py
+++ b/gitlab3/__init__.py
@@ -428,7 +428,7 @@ class _GitLabAPI(object):
         url = self._get_url(api_url, addl_keys)
         #print "%s %s, data=%s" % (request_fn.__name__.upper(), url, str(data))
         try:
-            if request_fn == requests.get:
+            if request_fn == requests.get or request_fn == requests.head:
               url = url + '?' + urllib.urlencode(data,doseq=True)
               data=None
             r = request_fn(url, headers=self._headers, data=data,


### PR DESCRIPTION
The default bitnami setup for Gitlab uses Apache+Passenger.

As detailed in this issue https://code.google.com/p/phusion-passenger/issues/detail?id=1069 Passenger returns a 400 as soon as a GET or HEAD request contains a request body.  This means that any index that was being passed paged parameters (.projects(), .groups(), etc.) all raise an error.

This patch encodes the data to URL parameters for GET and HEAD requests so that it will work with the bitnami Gitlab VM.
