### PR TITLE
Adding namespace support for project create

### DIFF
--- a/gitlab3/_api_definition.py
+++ b/gitlab3/_api_definition.py
@@ -143,6 +143,7 @@ class Project(APIDefinition):
     optional_params = [
         'description',
         'default_branch',
+        'namespace_id',
         'issues_enabled',
         'wall_enabled',
         'merge_requests_enabled',


### PR DESCRIPTION
Adding the 'namespace_id' to the optional parameters for the Project class.  This allows to utilize the API to create a project in a specific namespace instead of in the calling user's namespace
